### PR TITLE
[footer & recipe-list]: Add API for Main Categories

### DIFF
--- a/src/components/common/search-bar/SearchSection.tsx
+++ b/src/components/common/search-bar/SearchSection.tsx
@@ -78,7 +78,7 @@ export default function SearchSection({
 					)}
 
 					{showSearchBar && (
-						<div className="w-full max-w-8xl py-8">
+						<div className="w-full max-w-8xl">
 							<SearchBar
 								placeholder={searchPlaceholder}
 								value={searchValue}

--- a/src/features/footer/Footer.tsx
+++ b/src/features/footer/Footer.tsx
@@ -6,6 +6,7 @@ import { useAppSelector, useAppDispatch } from "@/hooks/redux";
 import type { FooterColumn, FooterLink } from './footer-data';
 import { useEffect } from 'react';
 import { fetchAllCategories } from '@/store/features/categorySlice';
+import { formatCategoryType } from '@/lib/utils';
 
 export default function Footer() {
 	const dispatch = useAppDispatch();
@@ -19,8 +20,8 @@ export default function Footer() {
 
 	// Tạo FooterLink[] từ categories
 	const mainCategoryLinks: FooterLink[] = Object.keys(categoriesByType).map(cat => ({
-		label: cat,        
-		href: '#' // Link đến trang category
+		label: formatCategoryType(cat),       
+		href: `/recipes?categoryType=${cat}`,
 	}));
 
 	// Tạo footerColumns mới, thay cột Main Categories bằng dynamic links

--- a/src/features/header/components/categories/Categories.tsx
+++ b/src/features/header/components/categories/Categories.tsx
@@ -2,6 +2,7 @@ import { useMemo } from "react";
 import type { Category as HeaderCategory } from "./CategoryList";
 import CategoryList from "./CategoryList";
 import type { Category } from '@/types/TypeRecipe';
+import { formatCategoryType } from '@/lib/utils';
 
 export type CategoriesProps = {
   itemsByType: Record<string, Category[]>;
@@ -12,7 +13,7 @@ export default function Categories({ itemsByType }: CategoriesProps) {
   const headerCategories: HeaderCategory[] = useMemo(() => {
     return Object.entries(itemsByType).map(([type, cats]) => ({
       id: type,
-      label: type, // hiển thị tên type trên dropdown
+      label: formatCategoryType(type), // hiển thị tên type trên dropdown
       items: cats.map(cat => ({
         id: cat.id,
         label: cat.name,

--- a/src/services/recipe.service.ts
+++ b/src/services/recipe.service.ts
@@ -1,5 +1,5 @@
 import axiosInstance from './axiosInstance';
-import type { Recipe } from '@/types/TypeRecipe';
+import type { Recipe} from '@/types/TypeRecipe';
 // recipe service functions:
 // getAllRecipes, getRecipesByCategory, getRecipeById, addRecipe, updateRecipe, deleteRecipe,...
 
@@ -29,9 +29,10 @@ export const getRecipeById = async (id: string) => {
 export const getRecipesByCategory = async (categoryName: string): Promise<Recipe[]> => {
 	try {
 		const response = await axiosInstance.get(
-			`/api/recipe/get?filter=${encodeURIComponent(categoryName)}`,
+			`/api/recipe/get?category=${encodeURIComponent(categoryName)}`,
 			{ withCredentials: true },
 		);
+		console.log(response.data.data.recipes)
 		return response.data.data.recipes;
 	} catch (error) {
 		console.error(`Error fetching recipes by category: ${categoryName}`, error);
@@ -99,3 +100,15 @@ export const removeFavoriteRecipe = async (userId: string, recipeId: string) => 
 		throw err;
 	}
 };
+
+export const getRecipesByCategoryType = async (categoryType: string): Promise<Recipe[]> => {
+	try {
+	  const response = await axiosInstance.get(`/api/recipe/get?categoryType=${encodeURIComponent(categoryType)}`, {
+		withCredentials: true,
+	  });
+	  return response.data.data.recipes;
+	} catch (error) {
+	  console.error("Error fetching recipes by category:", error);
+	  throw error;
+	}
+  };

--- a/src/store/features/categorySlice.tsx
+++ b/src/store/features/categorySlice.tsx
@@ -2,7 +2,6 @@ import { createSlice, createAsyncThunk } from '@reduxjs/toolkit';
 import type { PayloadAction } from '@reduxjs/toolkit'
 import type { Recipe, Category } from '@/types/TypeRecipe';
 import { getAllCategories } from '@/services/category.service';
-import { formatCategoryType } from '@/lib/utils';
 
 export interface CategoryState {
     recipesById: Record<string, Recipe>; 
@@ -31,12 +30,7 @@ export const fetchAllCategories = createAsyncThunk(
     async () => {
         const categories = await getAllCategories();
   
-        const formattedCategories = categories.map(cat => ({
-            ...cat,
-            type: formatCategoryType(cat.type)
-        }));
-  
-        return formattedCategories; // trả về Category[]
+        return categories; // trả về Category[]
     }
 );
 

--- a/src/store/features/recipeAPISlice.tsx
+++ b/src/store/features/recipeAPISlice.tsx
@@ -8,7 +8,8 @@ import {
 	updateRecipeRating,
 	addFavoriteRecipe,
 	removeFavoriteRecipe,
-	getFavoriteRecipes, // Added getFavoriteRecipes import
+	getFavoriteRecipes,
+	getRecipesByCategoryType, // Added getFavoriteRecipes import
 } from '@/services/recipe.service';
 import type { RootState } from '../store';
 // Contains API for Recipe Service
@@ -16,6 +17,7 @@ import type { RootState } from '../store';
 export interface RecipeState {
 	recipesById: Record<string, Recipe>;
 	recipesByCategory: Record<string, Recipe[]>;
+	recipesByCategoryType: Record<string, Recipe[]>;
 	allRecipes: Recipe[];
 	favoriteRecipesList: Recipe[]; // Full favorite recipes list
 	loading: boolean;
@@ -25,6 +27,7 @@ export interface RecipeState {
 const initialState: RecipeState = {
 	recipesById: {},
 	recipesByCategory: {},
+	recipesByCategoryType: {},
 	allRecipes: [],
 	favoriteRecipesList: [], // Initialize favorite recipes list
 	loading: false,
@@ -43,6 +46,14 @@ export const fetchRecipesByCategory = createAsyncThunk(
 		const data = await getRecipesByCategory(categoryName);
 		return { categoryName, data };
 	},
+);
+
+export const fetchRecipesByCategoryType = createAsyncThunk(
+	"recipe/fetchByCategoryType",
+	async (categoryType: string) => {
+	  const data = await getRecipesByCategoryType(categoryType);
+	  return { categoryType, recipes: data };
+	}
 );
 
 export const fetchAllRecipes = createAsyncThunk('recipes/fetchAll', async () => {
@@ -157,6 +168,21 @@ const recipeAPISlice = createSlice({
 			.addCase(fetchAllRecipes.rejected, (state, action) => {
 				state.loading = false;
 				state.error = action.error.message ?? 'Error';
+			})
+
+			// ===== fetchRecipesByCategoryType =====
+			.addCase(fetchRecipesByCategoryType.pending, (state) => {
+				state.loading = true;
+				state.error = null;
+			  })
+			.addCase(fetchRecipesByCategoryType.fulfilled, (state, action) => {
+				state.loading = false;
+				const { categoryType, recipes } = action.payload;
+				state.recipesByCategoryType[categoryType] = recipes;
+			})
+			.addCase(fetchRecipesByCategoryType.rejected, (state, action) => {
+				state.loading = false;
+				state.error = action.error.message ?? "Failed to fetch recipes by categoryType";
 			})
 
 			.addCase(submitRecipeRating.pending, state => {


### PR DESCRIPTION
## Footer

- [ ] Call API for Main Categories in Footer  
  - Click → navigate to `RecipeList Page`
  - `RecipeList Page` contains all recipes related to that `categoryType`

## API

- [ ] Add API `getRecipesByCategoryType`  
- [ ] Fix API `getRecipesByCategory`
